### PR TITLE
Fix requested OAuth scopes

### DIFF
--- a/pkg/xero/auth.go
+++ b/pkg/xero/auth.go
@@ -13,7 +13,7 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-var DefaultScopes = []string{"openid", "email", "profile", "offline_access", "accounting.settings", "accounting.transactions"}
+var DefaultScopes = []string{"accounting.settings.read"}
 
 type Auth struct {
 	Token        string


### PR DESCRIPTION
It's not possible to authorise most of the requested scopes when using
the `client_credentials` flow (a "Custom connection" app, in Xero
parlance). In fact, the only OAuth scope required by the connector is
`accounting.settings.read`, so just request that.
