### PR TITLE
Attempt re-auth if connector validation fails

### DIFF
--- a/pkg/xero/auth.go
+++ b/pkg/xero/auth.go
@@ -31,12 +31,15 @@ func NewAuth(token, refreshToken, clientId, clientSecret string) *Auth {
 	}
 }
 
-// This may be called if we have no token, or when the existing token has expired
+// This may be called if we have no token, or when the existing token has expired. Avoid calling
+// this if the token has been explicitly supplied to the connector.
 func (a *Auth) Login(ctx context.Context, httpClient *http.Client) error {
 	if a.ClientId == "" {
 		// access token must have been explicitly supplied to the connector
 		return fmt.Errorf("failed to authenticate: no client ID")
-	} else if a.RefreshToken == "" {
+	}
+
+	if a.RefreshToken == "" {
 		// this is a "custom connection" - use the client_credentials flow
 		// https://developer.xero.com/documentation/guides/oauth2/custom-connections/
 		t, _, err := ClientCredentialsFlow(ctx, httpClient, a.ClientId, a.ClientSecret)

--- a/pkg/xero/auth.go
+++ b/pkg/xero/auth.go
@@ -92,6 +92,11 @@ func RefreshTokenFlow(ctx context.Context, httpClient *http.Client, refreshToken
 	return t, rt, nil
 }
 
+type TokenResponse struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+}
+
 func exchangeToken(ctx context.Context, httpClient *http.Client, data *url.Values, auth *Auth) (string, string, error) {
 	baseUrl := &url.URL{Scheme: "https", Host: IdentityBase, Path: ExchangeTokenEndpoint}
 

--- a/pkg/xero/client.go
+++ b/pkg/xero/client.go
@@ -28,11 +28,10 @@ const (
 )
 
 type Client struct {
-	httpClient   *http.Client
-	baseUrl      *url.URL
-	token        string
-	refreshToken string
-	tenant       string
+	httpClient *http.Client
+	baseUrl    *url.URL
+	auth       *Auth
+	tenant     string
 }
 
 func NewClient(ctx context.Context, httpClient *http.Client, auth *Auth) (*Client, error) {
@@ -51,11 +50,10 @@ func NewClient(ctx context.Context, httpClient *http.Client, auth *Auth) (*Clien
 	}
 
 	return &Client{
-		httpClient:   httpClient,
-		baseUrl:      &url.URL{Scheme: "https", Host: ApiBase, Path: ApiEndpoint},
-		token:        auth.Token,
-		refreshToken: auth.RefreshToken,
-		tenant:       tenantId,
+		httpClient: httpClient,
+		baseUrl:    &url.URL{Scheme: "https", Host: ApiBase, Path: ApiEndpoint},
+		auth:       auth,
+		tenant:     tenantId,
 	}, nil
 }
 
@@ -157,7 +155,7 @@ func (c *Client) doRequest(
 
 	req.Header.Set("content-type", "application/json")
 	req.Header.Set("accept", "application/json")
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.token))
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.auth.Token))
 	req.Header.Set("xero-tenant-id", c.tenant)
 
 	rawResponse, err := c.httpClient.Do(req)

--- a/pkg/xero/client.go
+++ b/pkg/xero/client.go
@@ -64,11 +64,6 @@ func (c *Client) joinURL(path string) *url.URL {
 	return &newURL
 }
 
-type TokenResponse struct {
-	AccessToken  string `json:"access_token"`
-	RefreshToken string `json:"refresh_token"`
-}
-
 type UsersResponse struct {
 	Users []User `json:"users"`
 }

--- a/pkg/xero/client.go
+++ b/pkg/xero/client.go
@@ -39,7 +39,7 @@ func NewClient(ctx context.Context, httpClient *http.Client, auth *Auth) (*Clien
 	if auth.Token == "" {
 		err := auth.Login(ctx, httpClient)
 		if err != nil {
-			return nil, fmt.Errorf("failed to login: %w", err)
+			return nil, err
 		}
 	}
 

--- a/pkg/xero/client.go
+++ b/pkg/xero/client.go
@@ -57,6 +57,10 @@ func NewClient(ctx context.Context, httpClient *http.Client, auth *Auth) (*Clien
 	}, nil
 }
 
+func (c *Client) Login(ctx context.Context) error {
+	return c.auth.Login(ctx, c.httpClient)
+}
+
 func (c *Client) joinURL(path string) *url.URL {
 	newURL := *c.baseUrl
 	newURL.Path += path


### PR DESCRIPTION

As things stand, the Xero client is not able to handle the case where
its access token expires. This is because the client makes no attempt to
re-authenticate when connector validation fails due a 401 (Unauthorized)
response. This PR attempts reauthentication in these scenarios, allowing
the connector to continue working for more than 30 minutes at at time...

- Store Auth object in Xero client
- Move TokenResponse type to auth.go
- Clean up existing auth flows and handle missing clientId
- Attempt re-auth if connector validation fails
- Fix lint errors
