### PR TITLE
docs: update connector description

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -1,8 +1,8 @@
 ---
 title: Set up a Xero connector
 og:title: Set up a Xero connector - C1 docs
-og:description: Integrate your Xero instance with C1 to run user access reviews, enable just-in-time access requests, and easily provision and deprovision access.
-description: C1 provides identity governance and just-in-time provisioning for Xero. Integrate your Xero instance with C1 to run user access reviews (UARs) and enable just-in-time access requests.
+og:description: "C1 provides identity governance for Xero. Integrate your Xero instance with C1 for unified visibility and governance over user access."
+description: "C1 provides identity governance for Xero. Integrate your Xero instance with C1 for unified visibility and governance over user access."
 sidebarTitle: "Xero"
 ---
 
@@ -53,7 +53,7 @@ Click **Generate a secret**.
 Carefully copy and save the **Client secret**. 
 </Step>
 </Steps>
-**That's it!** Next, move on to the connector configuration instructions. 
+**Done.** Next, move on to the connector configuration instructions. 
 
 ## Configure the Xero connector 
 
@@ -187,7 +187,7 @@ Create a namespace in which to run C1 connectors (if desired), then apply the se
 Check that the connector data uploaded correctly. In C1, click **Apps**. On the **Managed apps** tab, locate and click the name of the application you added the Xero connector to. Xero data should be found on the **Entitlements** and **Accounts** tabs.
 </Step>
 </Steps>
-**That's it!** Your Xero connector is now pulling access data into C1.
+**Done.** Your Xero connector is now pulling access data into C1.
 </Tab>
 </Tabs>
 


### PR DESCRIPTION
Replicates changes from [ConductorOne/docs#221](https://github.com/ConductorOne/docs/pull/221).

- Removes inaccurate provisioning claims from the connector description
- Updates `**That's it!**` to `**Done.**` to align with brand voice guidelines