### PR TITLE
docs: update Docker image registry from GHCR to ECR Public

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -167,7 +167,7 @@ spec:
     spec:
       containers:
       - name: baton-xero
-        image: ghcr.io/conductorone/baton-xero:latest
+        image: public.ecr.aws/conductorone/baton-xero:latest
         imagePullPolicy: IfNotPresent
         env:
         - name: BATON_HOST_ID
@@ -192,4 +192,3 @@ Check that the connector data uploaded correctly. In C1, click **Apps**. On the 
 </Tabs>
 
 {/* metadata-sync: base-url config */}
-


### PR DESCRIPTION
## Summary

Connector images are now published exclusively to ECR Public (`public.ecr.aws/conductorone/`). This PR updates `docs/connector.mdx` accordingly.

**Changes made:**
- Updates Docker image reference from `ghcr.io/conductorone/` to `public.ecr.aws/conductorone/`
- Adds `### Resources` section (download center + GitHub repo links) if missing from the self-hosted setup instructions

_This PR was generated automatically._